### PR TITLE
feat: update cli --help, output prefix trimming

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ npm i -g ts2php
 $ ts2php ./a.ts                   # 编译输出到 stdout
 ```
 
-使用配置并输出到文件：
+使用[配置][options]并输出到文件：
 
 ```bash
 $ cat config.js
@@ -487,3 +487,5 @@ $ddd = array( "a" => strlen($str), "b" => strlen($str) + 1 );
 ## Thanks to
 
 Based on [Typescript](https://github.com/Microsoft/TypeScript) compiler
+
+[options]: https://max-team.github.io/ts2php/interfaces/ts2phpoptions.html


### PR DESCRIPTION
* 更新了 --help
* 只有一个输入目录时，输出时trim掉目录前缀：
    * `ts2php a.ts src/b.ts -o output` 会输出到 `output/a.php`, `output/src/b.php`
    * `ts2php src/ -o output/` 会把 `src/index.ts` 输出到 `output/index.php`