### PR TITLE
修复：一些不输出 'function', 'public' 的情况

### DIFF
--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -40,6 +40,8 @@ import {
     shouldAddDollar,
     shouldUseArray,
     shouldAddDoubleQuote,
+    isVisibilityModifier,
+    isSupportedPropertyModifier,
     isStringLike,
     isClassLike,
     isFunctionLike,
@@ -757,13 +759,15 @@ export function emitFile(
 
     function emitPropertyDeclaration(node: ts.PropertyDeclaration) {
         // emitDecorators(node, node.decorators);
-        if (node.modifiers) {
-            emitModifiers(node, node.modifiers);
-        }
-        else {
+        let modifiers = (node.modifiers || [] as any as ts.NodeArray<ts.Modifier>)
+            .filter(isSupportedPropertyModifier) as any as ts.NodeArray<ts.Modifier>
+
+        const hasVisibilityModifier = modifiers.some(isVisibilityModifier);
+        if (!hasVisibilityModifier) {
             writeKeyword('public');
             writeSpace();
         }
+        emitModifiers(node, modifiers);
         emit(node.name);
         // emit(node.questionToken);
         // emit(node.exclamationToken);

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -757,7 +757,13 @@ export function emitFile(
 
     function emitPropertyDeclaration(node: ts.PropertyDeclaration) {
         // emitDecorators(node, node.decorators);
-        emitModifiers(node, node.modifiers);
+        if (node.modifiers) {
+            emitModifiers(node, node.modifiers);
+        }
+        else {
+            writeKeyword('public');
+            writeSpace();
+        }
         emit(node.name);
         // emit(node.questionToken);
         // emit(node.exclamationToken);
@@ -784,6 +790,8 @@ export function emitFile(
         emitModifiers(node, node.modifiers);
         // emit(node.asteriskToken);
         if (ts.isClassDeclaration(node.parent)) {
+            writeKeyword("function");
+            writeSpace();
             emit(node.name);
         }
         else {
@@ -802,6 +810,8 @@ export function emitFile(
 
     function emitConstructor(node: ts.ConstructorDeclaration) {
         // emitModifiers(node, node.modifiers);
+        writeKeyword("function");
+        writeSpace();
         writeKeyword("__construct");
         emitSignatureAndBody(node, emitSignatureHead);
     }

--- a/src/utilities/nodeTest.ts
+++ b/src/utilities/nodeTest.ts
@@ -157,3 +157,13 @@ export function isFunctionLike(node: ts.Node, typeChecker: ts.TypeChecker) {
     const nodeSymbol = nodeType.getSymbol();
     return !!nodeSymbol && nodeSymbol.getFlags() === ts.SymbolFlags.Function;
 }
+
+export function isVisibilityModifier(node: ts.Modifier) {
+    return node.kind === SyntaxKind.PublicKeyword
+        || node.kind === SyntaxKind.PrivateKeyword
+        || node.kind === SyntaxKind.ProtectedKeyword;
+}
+
+export function isSupportedPropertyModifier(node: ts.Modifier) {
+    return isVisibilityModifier(node) || node.kind === SyntaxKind.StaticKeyword;
+}

--- a/test/features/Alias.php
+++ b/test/features/Alias.php
@@ -1,5 +1,5 @@
 <?php
-namespace test\Alias;
+namespace test\case_Alias;
 $a = "";
 $a .= "123";
 $b = 0;

--- a/test/features/ArrayApi.php
+++ b/test/features/ArrayApi.php
@@ -1,5 +1,5 @@
 <?php
-namespace test\ArrayApi;
+namespace test\case_ArrayApi;
 $a = count(array(1));
 $b = array(1, "a");
 $c = count($b);

--- a/test/features/ArrayLiteralExpression.php
+++ b/test/features/ArrayLiteralExpression.php
@@ -1,4 +1,4 @@
 <?php
-namespace test\ArrayLiteralExpression;
+namespace test\case_ArrayLiteralExpression;
 $b = 4;
 $a = array(1, 2, 3, $b);

--- a/test/features/Class.php
+++ b/test/features/Class.php
@@ -5,8 +5,9 @@ use \Base;
 class Article extends Base {
     public $title;
     public $id;
+    public $foo;
     private $_x;
-    static $published = array();
+    public static $published = array();
     function __construct($options) {
         parent::__construct($options);
         $this->title = $options["title"];

--- a/test/features/Class.php
+++ b/test/features/Class.php
@@ -1,18 +1,18 @@
 <?php
-namespace test\Class;
+namespace test\case_Class;
 require_once("../some-utils");
 use \Base;
 class Article extends Base {
     public $title;
-    $id;
+    public $id;
     private $_x;
     static $published = array();
-    __construct($options) {
+    function __construct($options) {
         parent::__construct($options);
         $this->title = $options["title"];
         $this->publish(1);
     }
-    private publish($id) {
+    private function publish($id) {
         array_push(Article::$published, $id);
         parent::dispose();
     }

--- a/test/features/Class.ts
+++ b/test/features/Class.ts
@@ -5,6 +5,7 @@ class Article extends Base {
 
     public title: string;
     id: number;
+    readonly foo: number;
 
     private _x: number;
 

--- a/test/features/ComputedPropertyName.php
+++ b/test/features/ComputedPropertyName.php
@@ -1,5 +1,5 @@
 <?php
-namespace test\ComputedPropertyName;
+namespace test\case_ComputedPropertyName;
 $a = "aaa";
 $b = "bbb";
 $c = array(

--- a/test/features/ConditionalExpression.php
+++ b/test/features/ConditionalExpression.php
@@ -1,4 +1,4 @@
 <?php
-namespace test\ConditionalExpression;
+namespace test\case_ConditionalExpression;
 $b = false;
 $a = $b ? 1 : 2;

--- a/test/features/Destructuring.php
+++ b/test/features/Destructuring.php
@@ -1,5 +1,5 @@
 <?php
-namespace test\Destructuring;
+namespace test\case_Destructuring;
 $tplData = array( "a" => 1 );
 $difftime = isset($tplData["difftime"]) ? $tplData["difftime"] : 8;
 $a = $tplData["a"];

--- a/test/features/EnumDeclaration.php
+++ b/test/features/EnumDeclaration.php
@@ -1,5 +1,5 @@
 <?php
-namespace test\EnumDeclaration;
+namespace test\case_EnumDeclaration;
 $aaa = array( "a" => 1, "b" => 2, "c" => 3 );
 $bbb = array( "a" => 0, "b" => 1, "c" => 2 );
 $ccc = array( "a" => "a", "b" => "b", "c" => "c" );

--- a/test/features/ForStatement.php
+++ b/test/features/ForStatement.php
@@ -1,5 +1,5 @@
 <?php
-namespace test\ForStatement;
+namespace test\case_ForStatement;
 $b = 1;
 for ($i = 0; $i < 10; $i++) {
     $b += 10;

--- a/test/features/FunctionDeclaration.php
+++ b/test/features/FunctionDeclaration.php
@@ -1,5 +1,5 @@
 <?php
-namespace test\FunctionDeclaration;
+namespace test\case_FunctionDeclaration;
 function aaa($a, $b, $c) {
     $d = 123;
     $e = $b . 123;

--- a/test/features/GlobalApi.php
+++ b/test/features/GlobalApi.php
@@ -1,5 +1,5 @@
 <?php
-namespace test\GlobalApi;
+namespace test\case_GlobalApi;
 $a = intval("1.2");
 $b = floatval("1.2");
 $c = \Ts2Php_Helper::typeof($a);

--- a/test/features/IfStatement.php
+++ b/test/features/IfStatement.php
@@ -1,5 +1,5 @@
 <?php
-namespace test\IfStatement;
+namespace test\case_IfStatement;
 $a = true;
 if (!$a) {
     $b = 456;

--- a/test/features/Math.php
+++ b/test/features/Math.php
@@ -1,3 +1,3 @@
 <?php
-namespace test\Math;
+namespace test\case_Math;
 $a = max(1, 2);

--- a/test/features/NumberApi.php
+++ b/test/features/NumberApi.php
@@ -1,5 +1,5 @@
 <?php
-namespace test\NumberApi;
+namespace test\case_NumberApi;
 $a = 12.44;
 $b = round($a, 1);
 $c = round(($a + 1), 1);

--- a/test/features/ObjectJSON.php
+++ b/test/features/ObjectJSON.php
@@ -1,5 +1,5 @@
 <?php
-namespace test\ObjectJSON;
+namespace test\case_ObjectJSON;
 $a = array_merge(array(), array( "a" => 1 ));
 $b = array_keys($a);
 $c = $a;

--- a/test/features/ObjectLiteralExpression.php
+++ b/test/features/ObjectLiteralExpression.php
@@ -1,5 +1,5 @@
 <?php
-namespace test\ObjectLiteralExpression;
+namespace test\case_ObjectLiteralExpression;
 $b = array(
     "a" => 123,
     "b" => "456"

--- a/test/features/ShorthandPropertyAssignment.php
+++ b/test/features/ShorthandPropertyAssignment.php
@@ -1,5 +1,5 @@
 <?php
-namespace test\ShorthandPropertyAssignment;
+namespace test\case_ShorthandPropertyAssignment;
 $b = 2;
 $c = 1;
 $a = array(

--- a/test/features/SwitchStatement.php
+++ b/test/features/SwitchStatement.php
@@ -1,5 +1,5 @@
 <?php
-namespace test\SwitchStatement;
+namespace test\case_SwitchStatement;
 $b = 2;
 $c = 1;
 switch ($b) {

--- a/test/features/WhileStatement.php
+++ b/test/features/WhileStatement.php
@@ -1,5 +1,5 @@
 <?php
-namespace test\WhileStatement;
+namespace test\case_WhileStatement;
 $a = true;
 $b;
 while (!$a) {

--- a/test/features/addDollar.php
+++ b/test/features/addDollar.php
@@ -1,5 +1,5 @@
 <?php
-namespace test\addDollar;
+namespace test\case_addDollar;
 $a = "123";
 $b = array();
 $b[$a] = 123;

--- a/test/features/elementAccessExpression.php
+++ b/test/features/elementAccessExpression.php
@@ -1,5 +1,5 @@
 <?php
-namespace test\elementAccessExpression;
+namespace test\case_elementAccessExpression;
 $tplData = array();
 $a = "aaa";
 $tplData[$a] = 123;

--- a/test/features/export.php
+++ b/test/features/export.php
@@ -1,5 +1,5 @@
 <?php
-namespace test\export;
+namespace test\case_export;
 function run($a) {
     $b = "111";
     var_dump($a, $b);

--- a/test/features/import.php
+++ b/test/features/import.php
@@ -1,5 +1,5 @@
 <?php
-namespace test\import;
+namespace test\case_import;
 require_once("../some-utils");
 use \Other_Utils as Util;
 use \Some_Utils;

--- a/test/features/stringProto.php
+++ b/test/features/stringProto.php
@@ -1,5 +1,5 @@
 <?php
-namespace test\stringProto;
+namespace test\case_stringProto;
 $a = "wwa";
 $b = \Ts2Php_Helper::str_replace_once("a", "b", $a);
 $c = array( "s" => "aaa" );

--- a/test/features/template.php
+++ b/test/features/template.php
@@ -1,5 +1,5 @@
 <?php
-namespace test\template;
+namespace test\case_template;
 $b = "123";
 $c = "0" . $b . "45'6'\"789\"";
 $s = "1" . $b . "2" . $b . "3" . $b . "4";

--- a/test/features/vue.php
+++ b/test/features/vue.php
@@ -1,5 +1,5 @@
 <?php
-namespace test\vue;
+namespace test\case_vue;
 $Vue["extend"](array(
     "props" => array(
         "b" => $String,

--- a/test/index.js
+++ b/test/index.js
@@ -12,7 +12,7 @@ const {compile} = require('../src/index.ts');
 
 const files = fs.readdirSync(path.resolve(__dirname, './features'));
 const featureNames = files.reduce((res, file) => {
-    const m = file.match(/(.+)\.ts/);
+    const m = file.match(/(.+)\.ts$/);
     if (m) {
         res.push(m[1]);
     }
@@ -39,7 +39,7 @@ describe('features', () => {
             const phpContent = await readFile(path.resolve(__dirname, `./features/${featureName}.php`));
             const tsPath = path.resolve(__dirname, `./features/${featureName}.ts`);
             const res = compile(tsPath, {
-                namespace: `test\\${featureName}`,
+                namespace: `test\\case_${featureName}`,
                 modules: {
                     'vue': {
                         required: true


### PR DESCRIPTION
1. 修复构造函数和方法没有emit `function` 的bug。
2. 修复属性没有默认 modifier 的bug：php 属性必须有 modifier。TypeScript默认是public。
3. 修复测试桩里不合法的namespace名字 `test\Class`，统一前缀 `test/case_`。