### PR TITLE
feat: pass by reference when the arg is an object

### DIFF
--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -729,6 +729,14 @@ export function emitFile(
         // emitDecorators(node, node.decorators);
         // emitModifiers(node, node.modifiers);
         // emit(node.dotDotDotToken);
+
+        if (node.parent && node.parent.kind === SyntaxKind.FunctionDeclaration) {
+            const type = typeChecker.getTypeAtLocation(node.name);
+            if (type && type.flags === ts.TypeFlags.Object) {
+                write('&');
+            }
+        }
+
         emitNodeWithWriter(node.name, writeParameter);
         // emit(node.questionToken);
         if (node.parent && node.parent.kind === SyntaxKind.JSDocFunctionType && !node.name) {

--- a/test/features/ArrayApi.php
+++ b/test/features/ArrayApi.php
@@ -18,7 +18,7 @@ $t = \Ts2Php_Helper::isPlainArray($a);
 $x = array( "u" => array() );
 $v = count($x["u"]);
 echo "<script>console.log(" . json_encode($x) . ");</script>";
-function run($x) {
+function run(&$x) {
     \Ts2Php_Helper::arraySlice($x["y"], 1);
     array_push($x["y"], 1);
 }

--- a/test/features/funcParamRefer.php
+++ b/test/features/funcParamRefer.php
@@ -1,0 +1,13 @@
+<?php
+namespace test\case_funcParamRefer;
+$a = array(1, 2, 3);
+$b = array(
+    "a" => 1
+);
+$c = "123";
+function aaa(&$m, &$n, $k) {
+    array_push($m, 4);
+    $n["b"] = 2;
+    $k .= "4";
+}
+aaa($a, $b, $c);

--- a/test/features/funcParamRefer.ts
+++ b/test/features/funcParamRefer.ts
@@ -1,0 +1,13 @@
+let a = [1, 2, 3];
+let b = {
+    a: 1
+};
+let c = '123';
+
+function aaa(m: number[], n: {[name: string]: number}, k: string) {
+    m.push(4);
+    n.b = 2;
+    k += '4';
+}
+
+aaa(a, b, c);


### PR DESCRIPTION
funciton abc(m: number[]) {
}

function abc(&$m) {
}