### PR TITLE
fix: missing parenthesis when trans arrow function

### DIFF
--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -2746,7 +2746,7 @@ export function emitFile(
 
     function emitParametersForArrow(parentNode: ts.FunctionTypeNode | ts.ArrowFunction, parameters: ts.NodeArray<ts.ParameterDeclaration>) {
         if (canEmitSimpleArrowHead(parentNode, parameters)) {
-            emitList(parentNode, parameters, ListFormat.Parameters & ~ListFormat.Parenthesis);
+            emitList(parentNode, parameters, (ListFormat.Parameters & ~ListFormat.Parenthesis) | ts.ListFormat.Parenthesis /* always add parenthesis */);
         }
         else {
             emitParameters(parentNode, parameters);

--- a/test/features/arrowFunction.php
+++ b/test/features/arrowFunction.php
@@ -1,0 +1,9 @@
+<?php
+namespace test\case_arrowFunction;
+$arr = array();
+array_map(function ($item) {
+    return $item . "";
+}, $arr);
+$a = function ($b){
+return "123";
+};

--- a/test/features/arrowFunction.ts
+++ b/test/features/arrowFunction.ts
@@ -1,0 +1,6 @@
+let arr = [];
+arr.map(item => {
+    return item + '';
+});
+
+let a = b => '123';


### PR DESCRIPTION
```javascript
arr.map(a => {})
```
is mistakenly compiled to
```php
array_map(function a {}, $arr);
```

should be
```php
array_map(function (a) {}, $arr);
```
