### PR TITLE
Startswith

### DIFF
--- a/src/runtime/Ts2Php_Helper.php
+++ b/src/runtime/Ts2Php_Helper.php
@@ -59,8 +59,11 @@ class Ts2Php_Helper {
      * @param $postion {number}
      * @return {boolean}
      */
-    static public function startsWith($origin, $substr, $postion = 0){
-        return strncmp($substr, $origin, strlen($substr)) === $postion;
+    static public function startsWith($origin, $substr, $position = 0){
+        if ($position !== 0) {
+            $origin = substr($origin, $position);
+        }
+        return strncmp($substr, $origin, strlen($substr)) === 0;
     }
 
     /**

--- a/test/runtime/autoload.php
+++ b/test/runtime/autoload.php
@@ -10,8 +10,8 @@ function my_autoloader($classname) {
         'Ts2Php_Helper' => 'Ts2Php_Helper.php',
     );
 
-    if (isset($smartyClassMap[$classname])) {
-        require_once ($smartyClassMap[$classname]);
+    if (isset($rumtimeClassMap[$classname])) {
+        require_once ($runtimeDir . $rumtimeClassMap[$classname]);
     }
 }
 


### PR DESCRIPTION
1. 修复了一下 autoload，之前没有生效。
2. 修改了 startswith 的实现方式。之前的实现方式，当两个字符串不相等时，strncmp 函数的返回值在不同 php 版本中不一致，得到错误的结果。