### PR TITLE
support string.prototype.match

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,7 @@ $g = array_merge(array(), $a, array(
   - String.prototype.endsWidth
   - String.prototype.includes
   - String.prototype.padStart
+  - String.prototype.match **只支持正则和字符串匹配**
 - Array
   - Array.isArray
   - Array.prototype.length

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -648,7 +648,7 @@ export function emitFile(
     }
 
     function emitRegularExpressionLiteral(node: ts.RegularExpressionLiteral) {
-        const text = JSON.stringify(getLiteralTextOfNode(node, true).replace(/g$/, ''));
+        const text = JSON.stringify(getLiteralTextOfNode(node, true).replace(/\/[^/]+$/, match => match.replace('g', '')));
         writeStringLiteral(text);
     }
 

--- a/src/features/string.ts
+++ b/src/features/string.ts
@@ -19,7 +19,8 @@ import {
     createIdentifier,
     createStringLiteral,
     SyntaxKind,
-    createTrue
+    createTrue,
+    createFalse
 } from 'typescript';
 
 import {
@@ -65,9 +66,20 @@ function match(node: CallExpression, {emitExpressionList, writePunctuation}, sta
     let isRegularExpressionLiteral = pattern.kind === SyntaxKind.RegularExpressionLiteral;
     let method = '%helper::match';
     let nodeList = [node.arguments[0], expNode.expression];
+
     if (!isRegularExpressionLiteral) {
+        // mark is string
         nodeList.push(createTrue());
     }
+    else {
+        // mark all match
+        let isAll = pattern.getText().split('/')[2].indexOf('g') != -1;
+        if (isAll) {
+            nodeList.push(createFalse());
+            nodeList.push(createTrue());
+        }
+    }
+
     writePunctuation(formatMethodName(method, state.helperClass));
     const args = createNodeArray(nodeList);
     emitExpressionList(node, args, ListFormat.CallExpressionArguments);

--- a/src/runtime/Ts2Php_Helper.php
+++ b/src/runtime/Ts2Php_Helper.php
@@ -98,27 +98,18 @@ class Ts2Php_Helper {
      * @param $subject {string}
      * @param $isStr {boolean}
      */
-    static public function match($patten, $subject, $isStr = false) {
+    static public function match($patten, $subject, $isStr = false, $isAll = false) {
         $matches = array();
     
         if ($isStr) {
             $patten = '/' . preg_quote($patten, '/') . '/';
         }
-        else {
-            // support g
-            $pattenArr = explode('/', $patten);
-            $marks = $pattenArr[2];
-            if (strpos($marks, 'g') !== false) {
-                $newMarks = str_ireplace('g', '', $marks);
-                $pattenArr[2] = $newMarks;
-                $patten = implode('/', $pattenArr);
-        
-                preg_match_all($patten, $subject, $matches);
-                if (empty($matches[0])) {
-                    return null;
-                }
-                return $matches[0];
+        else if ($isAll) {
+            preg_match_all($patten, $subject, $matches);
+            if (empty($matches[0])) {
+                return null;
             }
+            return $matches[0];
         }
     
     

--- a/src/runtime/Ts2Php_Helper.php
+++ b/src/runtime/Ts2Php_Helper.php
@@ -93,6 +93,60 @@ class Ts2Php_Helper {
     }
 
     /**
+     * string.prototype.match
+     * @param $patten {string}
+     * @param $subject {string}
+     * @param $isStr {boolean}
+     */
+    static public function match($patten, $subject, $isStr = false) {
+        $matches = array();
+    
+        if ($isStr) {
+            $patten = '/' . preg_quote($patten, '/') . '/';
+        }
+        else {
+            // support g
+            $pattenArr = explode('/', $patten);
+            $marks = $pattenArr[2];
+            if (strpos($marks, 'g') !== false) {
+                $newMarks = str_ireplace('g', '', $marks);
+                $pattenArr[2] = $newMarks;
+                $patten = implode('/', $pattenArr);
+        
+                preg_match_all($patten, $subject, $matches);
+                if (empty($matches[0])) {
+                    return null;
+                }
+                return $matches[0];
+            }
+        }
+    
+    
+        $res = preg_match($patten, $subject, $matches);
+        if ($res === 0) {
+            return null;
+        }
+    
+        // support group
+        $group = array();
+        foreach($matches as $x=>$x_val) {
+            if (!is_numeric($x)) {
+                $group[$x] = $x_val;
+                unset($matches[$x]);
+            }
+        }
+        if (!empty($group)) {
+            $matches['group'] = $group;
+        }
+    
+        // index, input
+        $matches['index'] = strpos($subject, $matches[0]);
+        $matches['input'] = $subject;
+    
+        return $matches;
+    }
+
+    /**
      * string.prototype.indexOf
      * @param $haystack {string}
      * @param $needle {string}

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,6 @@ import {Ts2phpOptions, ErrorInfo} from '../types/index';
 export interface CompilerState extends Ts2phpOptions {
     errors: ErrorInfo[],
     typeChecker: ts.TypeChecker,
-    helpers: {},
+    helpers: any,
     sourceFile?: ts.SourceFile
 }

--- a/test/features/stringMatch.php
+++ b/test/features/stringMatch.php
@@ -1,6 +1,7 @@
 <?php
 namespace test\case_stringMatch;
 $a = "abc";
-$b = \Ts2Php_Helper::match("/a/", $a);
-$c = \Ts2Php_Helper::match("/a(?<name>bc)/", $a);
-$d = \Ts2Php_Helper::match("a", $a, true);
+$b = \Ts2Php_Helper::match("/a/i", $a, false, true);
+$c = \Ts2Php_Helper::match("/a(?<name>bc)/i", $a, false, true);
+$d = \Ts2Php_Helper::match("/a(?<name>bc)/", $a, false, true);
+$e = \Ts2Php_Helper::match("a", $a, true);

--- a/test/features/stringMatch.php
+++ b/test/features/stringMatch.php
@@ -1,0 +1,6 @@
+<?php
+namespace test\case_stringMatch;
+$a = "abc";
+$b = \Ts2Php_Helper::match("/a/", $a);
+$c = \Ts2Php_Helper::match("/a(?<name>bc)/", $a);
+$d = \Ts2Php_Helper::match("a", $a, true);

--- a/test/features/stringMatch.ts
+++ b/test/features/stringMatch.ts
@@ -1,0 +1,5 @@
+let a = 'abc';
+
+let b = a.match(/a/g);
+let c = a.match(/a(?<name>bc)/g);
+let d = a.match('a');

--- a/test/features/stringMatch.ts
+++ b/test/features/stringMatch.ts
@@ -1,5 +1,6 @@
 let a = 'abc';
 
-let b = a.match(/a/g);
-let c = a.match(/a(?<name>bc)/g);
-let d = a.match('a');
+let b = a.match(/a/gi);
+let c = a.match(/a(?<name>bc)/ig);
+let d = a.match(/a(?<name>bc)/g);
+let e = a.match('a');

--- a/test/runtime/spec/Ts2Php_HelperTest.php
+++ b/test/runtime/spec/Ts2Php_HelperTest.php
@@ -259,7 +259,7 @@ final class Ts2Php_HelperTest extends TestCase {
         );
 
         $this->assertEquals(
-            \Ts2Php_Helper::match("/a/ig", "aaa"),
+            \Ts2Php_Helper::match("/a/i", "aaa", false, true),
             array(
                 "a",
                 "a",

--- a/test/runtime/spec/Ts2Php_HelperTest.php
+++ b/test/runtime/spec/Ts2Php_HelperTest.php
@@ -238,4 +238,56 @@ final class Ts2Php_HelperTest extends TestCase {
         $this->assertTrue($result > 0);
         $this->assertTrue($result < 1);
     }
+
+    public function testMatch() {
+        $this->assertEquals(
+            \Ts2Php_Helper::match("/a/", "aaa"),
+            array(
+                "0" => "a",
+                "index" => 0,
+                "input" => "aaa"
+            )
+        );
+
+        $this->assertEquals(
+            \Ts2Php_Helper::match("a", "aaa", true),
+            array(
+                "0" => "a",
+                "index" => 0,
+                "input" => "aaa"
+            )
+        );
+
+        $this->assertEquals(
+            \Ts2Php_Helper::match("/a/ig", "aaa"),
+            array(
+                "a",
+                "a",
+                "a"
+            )
+        );
+
+        $this->assertEquals(
+            \Ts2Php_Helper::match("/a(bc)/", "abcdef"),
+            array(
+                "0" => "abc",
+                "1" => "bc",
+                "index" => 0,
+                "input" => "abcdef"
+            )
+        );
+
+        $this->assertEquals(
+            \Ts2Php_Helper::match("/a(?<name>bc)/", "abcdef"),
+            array(
+                "0" => "abc",
+                "1" => "bc",
+                "index" => 0,
+                "input" => "abcdef",
+                "group" => array(
+                    "name" => "bc"
+                )
+            )
+        );
+    }
 }


### PR DESCRIPTION
1. support label `g`：`/abc/g`.
2. support name group: `/a(?<name>bc)/`.
3. only support `string` and `regex`.