### PR TITLE
feat: support access interface method using ->, see #23

### DIFF
--- a/src/utilities/nodeTest.ts
+++ b/src/utilities/nodeTest.ts
@@ -166,11 +166,38 @@ export function isClassLike(node: ts.Node, typeChecker: ts.TypeChecker) {
 export function isClassInstance(node: ts.Node, typeChecker: ts.TypeChecker) {
     const nodeType = typeChecker.getTypeAtLocation(node);
     const nodeSymbol = typeChecker.getSymbolAtLocation(node);
+
+    const baseTypeName = getBaseTypeName(nodeType)
+    if (baseTypeName === 'PHPClass') return true
+    if (baseTypeName === 'PHPArray') return false
+
     if (!nodeSymbol) {
         return false;
     }
     return (nodeType.isClass() && !(nodeSymbol.getFlags() & ts.SymbolFlags.Class))
         || (nodeType.objectFlags & ts.ObjectFlags.Interface) && nodeType.symbol.getEscapedName() === 'Date';
+}
+
+// 通过最近的父类来确定是用对象（->）还是数组（[]）
+// 优化：遍历父类有的方法来确定用哪个父类
+function getBaseTypeName(nodeType: ts.Type): 'PHPClass' | 'PHPArray' | 'other' {
+    const queue = [nodeType]
+
+    while(queue.length) {
+        const nodeType = queue.shift()
+        const baseTypes = nodeType.getBaseTypes()
+        if (!baseTypes) continue
+
+        for (const baseType of baseTypes) {
+            const baseSymbol = baseType.getSymbol()
+            if (!baseSymbol) continue
+
+            const name = baseSymbol.getName()
+            if (name === 'PHPClass' || name === 'PHPArray') return name
+            else queue.push(baseType)
+        }
+    }
+    return 'other'
 }
 
 export function isFunctionLike(node: ts.Node, typeChecker: ts.TypeChecker) {

--- a/test/features/interfaceAsClass.php
+++ b/test/features/interfaceAsClass.php
@@ -1,0 +1,11 @@
+<?php
+namespace test\case_interfaceAsClass;
+class Cls {
+    function log() {
+        echo "foo";
+    }
+}
+$foo = new Cls();
+($foo)->log();
+($foo)->log();
+($foo)["log"]();

--- a/test/features/interfaceAsClass.ts
+++ b/test/features/interfaceAsClass.ts
@@ -1,0 +1,23 @@
+import { PHPClass, PHPArray } from '../..'
+
+class Cls implements I1 {
+    log() {
+        console.log('foo')
+    }
+}
+
+interface I1 extends PHPClass {
+    log(): void
+}
+
+interface I2 extends I1 {
+    log(): void
+}
+
+interface I3 extends I1, PHPArray { }
+
+const foo = new Cls();
+
+(foo as I1).log();  // direct base is PHPClass
+(foo as I2).log();  // indirect base is PHPClass
+(foo as I3).log();  // nearest base is PHPArray

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -117,6 +117,10 @@ export interface Ts2phpOptions {
     customTransformers?: ts.TransformerFactory<ts.SourceFile | ts.Bundle>[]
 }
 
+export interface PHPClass {}
+
+export interface PHPArray {}
+
 /**
  * 编译入口
  *


### PR DESCRIPTION
单纯支持 #23 中的调用处语法，用来方便地引用外部定义的interface（当作class来用）。用来解决 san-ssr 中的这个重构遇到的问题：

https://github.com/searchfe/san-ssr/pull/18