### PR TITLE
perf: allow single typescript project instance

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,7 +31,7 @@
         "@typescript-eslint/prefer-namespace-keyword": "error",
 
         "quotes": "off",
-        "@typescript-eslint/quotes": ["error", "double", { "avoidEscape": true, "allowTemplateLiterals": true }],
+        "@typescript-eslint/quotes": ["error", "single", { "avoidEscape": true, "allowTemplateLiterals": true }],
 
         "semi": "off",
         "@typescript-eslint/semi": "error",
@@ -70,7 +70,7 @@
         "curly": ["error", "multi-line"],
         "dot-notation": "error",
         "eqeqeq": "error",
-        "linebreak-style": ["error", "windows"],
+        "linebreak-style": ["error", "unix"],
         "new-parens": "error",
         "no-caller": "error",
         "no-duplicate-case": "error",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@
 
 import fs from 'fs-extra';
 import path from 'path';
-import {Project, ts} from 'ts-morph';
+import {Project, ts, CompilerOptions} from 'ts-morph';
 import {upperFirst} from 'lodash';
 import {satisfies} from 'semver';
 
@@ -14,7 +14,7 @@ import {CompilerState} from './types';
 import {setState} from './state';
 import buildInPlugins from './features/index';
 import {transform} from './transformer';
-import {Ts2phpOptions, ModuleInfo} from '../types/index';
+import {Ts2phpOptions, Ts2phpConstructOptions, Ts2phpCompileOptions, ModuleInfo} from '../types/index';
 
 const defaultOptions = {
     showDiagnostics: true,
@@ -43,114 +43,123 @@ const getRandomString = n => Array(n)
         return s.charAt(Math.floor(Math.random() * s.length));
     }).join('');
 
+export class Ts2Php {
+    private project: Project;
 
-export function compile(filePath: string, options: Ts2phpOptions = {}) {
-
-    if (!satisfies(ts.version, '~3.4.0')) {
-        throw new TypeError('[ts2php] TypeScript version ' + ts.version + ' is not valid! Please install typescript@~3.4.0!');
-    }
-
-    const project = new Project({
-        compilerOptions: {
-            target: ts.ScriptTarget.ES2016,
-            scrict: true,
-            module: ts.ModuleKind.CommonJS,
-            noImplicitThis: true,
-            noImplicitAny: true,
-            alwaysStrict: true,
-            ...options.compilerOptions
-        },
-        addFilesFromTsConfig: false,
-        skipFileDependencyResolution: true
-    });
-
-    let sourceFile;
-
-    if (!options.source && fs.existsSync(filePath)) {
-        sourceFile = project.addExistingSourceFile(filePath);
-    }
-    else if (options.source) {
-        filePath = /\.ts$/.test(filePath) ? filePath : (filePath + '.ts');
-        sourceFile = project.createSourceFile(filePath, options.source, {overwrite: true});
-    }
-    else {
-        return {
-            phpCode: '',
-            errors: [{
-                code: 501,
-                msg: '未找到文件'
-            }]
-        };
-    }
-
-    project.resolveSourceFileDependencies();
-    const program = project.getProgram().compilerObject;
-
-    const finalOptions = {
-        ...defaultOptions,
-        ...options
-    };
-    // avoid change options
-    finalOptions.modules = Object.assign({}, options.modules);
-
-    const typeChecker = program.getTypeChecker();
-
-    let diagnostics = project.getPreEmitDiagnostics();
-    if (finalOptions.showDiagnostics) {
-        diagnostics = diagnostics.filter(a => a.compilerObject.code !== 2307)
-        let diags = diagnostics.map(a => a.compilerObject);
-        if (diags.length) {
-            console.log(project.formatDiagnosticsWithColorAndContext(diagnostics));
-            return {
-                phpCode: '',
-                errors: diags
-            };
+    constructor ({ compilerOptions }: Ts2phpConstructOptions = {}) {
+        if (!satisfies(ts.version, '~3.4.0')) {
+            throw new TypeError('[ts2php] TypeScript version ' + ts.version + ' is not valid! Please install typescript@~3.4.0!');
         }
-    }
 
-    const plugins = (finalOptions && finalOptions.plugins) ? [...buildInPlugins, ...finalOptions.plugins] : buildInPlugins;
-
-    const state: CompilerState = Object.assign({}, finalOptions, {
-        errors: [],
-        typeChecker,
-        helpers: {},
-        moduleNamedImports: {},
-        moduleDefaultImports: {},
-        namespace: (options && options.namespace)
-            || (options && options.getNamespace && options.getNamespace(filePath))
-            || upperFirst(getRandomString(5)),
-        plugins
-    });
-
-    setState(state);
-
-    const transformers: ts.TransformerFactory<ts.SourceFile | ts.Bundle>[] = [
-        transform,
-        ...(options.customTransformers || [])
-    ];
-
-    let sourceFileNode = sourceFile.compilerNode;
-
-    const emitResolver = program.getDiagnosticsProducingTypeChecker()
-        .getEmitResolver(sourceFileNode, undefined);
-
-    if (sourceFileNode.resolvedModules) {
-        sourceFileNode.resolvedModules.forEach((item, name) => {
-            let moduleIt = state.modules[name] || {} as ModuleInfo;
-            state.modules[name] = {
-                name,
-                pathCode: state.getModulePathCode(name, item, moduleIt),
-                namespace: state.getModuleNamespace(name, item, moduleIt),
-                ...moduleIt
-            };
+        this.project = new Project({
+            compilerOptions: {
+                target: ts.ScriptTarget.ES2016,
+                scrict: true,
+                module: ts.ModuleKind.CommonJS,
+                noImplicitThis: true,
+                noImplicitAny: true,
+                alwaysStrict: true,
+                ...compilerOptions
+            },
+            addFilesFromTsConfig: false,
+            skipFileDependencyResolution: true
         });
     }
 
-    const code = emitter.emitFile(sourceFileNode, state, emitResolver, transformers);
+    compile (filePath: string, options: Ts2phpCompileOptions = {}) {
+        let sourceFile;
 
-    return {
-        phpCode: code,
-        errors: state.errors,
-        sourceFile: state.sourceFile
-    };
+        if (!options.source && fs.existsSync(filePath)) {
+            sourceFile = this.project.addExistingSourceFile(filePath);
+        }
+        else if (options.source) {
+            filePath = /\.ts$/.test(filePath) ? filePath : (filePath + '.ts');
+            sourceFile = this.project.createSourceFile(filePath, options.source, {overwrite: true});
+        }
+        else {
+            return {
+                phpCode: '',
+                errors: [{
+                    code: 501,
+                    msg: '未找到文件'
+                }]
+            };
+        }
+
+        this.project.resolveSourceFileDependencies();
+        const program = this.project.getProgram().compilerObject;
+
+        const finalOptions = {
+            ...defaultOptions,
+            ...options
+        };
+        // avoid change options
+        finalOptions.modules = {...options.modules};
+
+        const typeChecker = program.getTypeChecker();
+
+        let diagnostics = this.project.getPreEmitDiagnostics();
+        if (finalOptions.showDiagnostics) {
+            diagnostics = diagnostics.filter(a => a.compilerObject.code !== 2307);
+            const diags = diagnostics.map(a => a.compilerObject);
+            if (diags.length) {
+                console.log(this.project.formatDiagnosticsWithColorAndContext(diagnostics));
+                return {
+                    phpCode: '',
+                    errors: diags
+                };
+            }
+        }
+
+        const plugins = (finalOptions && finalOptions.plugins) ? [...buildInPlugins, ...finalOptions.plugins] : buildInPlugins;
+
+        const state: CompilerState = {...finalOptions, ...{
+            errors: [],
+            typeChecker,
+            helpers: {},
+            moduleNamedImports: {},
+            moduleDefaultImports: {},
+            namespace: (options.namespace)
+                || (options.getNamespace && options.getNamespace(filePath))
+                || upperFirst(getRandomString(5)),
+            plugins
+        }};
+
+        setState(state);
+
+        const transformers: ts.TransformerFactory<ts.SourceFile | ts.Bundle>[] = [
+            transform,
+            ...(options.customTransformers || [])
+        ];
+
+        const sourceFileNode = sourceFile.compilerNode;
+
+        const emitResolver = program.getDiagnosticsProducingTypeChecker()
+            .getEmitResolver(sourceFileNode, undefined);
+
+        if (sourceFileNode.resolvedModules) {
+            sourceFileNode.resolvedModules.forEach((item, name) => {
+                const moduleIt = state.modules[name] || {} as ModuleInfo;
+                state.modules[name] = {
+                    name,
+                    pathCode: state.getModulePathCode(name, item, moduleIt),
+                    namespace: state.getModuleNamespace(name, item, moduleIt),
+                    ...moduleIt
+                };
+            });
+        }
+
+        const code = emitter.emitFile(sourceFileNode, state, emitResolver, transformers);
+
+        return {
+            phpCode: code,
+            errors: state.errors,
+            sourceFile: state.sourceFile
+        };
+    }
+}
+
+export function compile(filePath: string, options: Ts2phpOptions = {}) {
+    const ts2php = new Ts2Php(options.compilerOptions);
+    return ts2php.compile(filePath, options);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,6 +160,7 @@ export class Ts2Php {
 }
 
 export function compile(filePath: string, options: Ts2phpOptions = {}) {
-    const ts2php = new Ts2Php(options.compilerOptions);
+    const compilerOptions = options.compilerOptions;
+    const ts2php = new Ts2Php({ compilerOptions });
     return ts2php.compile(filePath, options);
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -41,7 +41,7 @@ export interface Ts2phpConstructOptions {
      *
      * @see See https://www.typescriptlang.org/docs/handbook/compiler-options.html
      */
-    compilerOptions?: CompilerOptions
+    compilerOptions?: ts.CompilerOptions
 }
 
 export interface Ts2phpCompileOptions {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -35,8 +35,16 @@ export interface ErrorInfo {
     msg: string;
 }
 
-export interface Ts2phpOptions {
+export interface Ts2phpConstructOptions {
+    /**
+     * TypeScript 编译配置
+     *
+     * @see See https://www.typescriptlang.org/docs/handbook/compiler-options.html
+     */
+    compilerOptions?: CompilerOptions
+}
 
+export interface Ts2phpCompileOptions {
     /**
      * 文件代码内容，真正被编译的代码
      **/
@@ -99,13 +107,6 @@ export interface Ts2phpOptions {
     getModuleNamespace?: (name: string, module?: ts.ResolvedModuleFull, moduleIt?: ModuleInfo) => string;
 
     /**
-     * TypeScript 编译配置
-     *
-     * @see See https://www.typescriptlang.org/docs/handbook/compiler-options.html
-     */
-    compilerOptions?: object,
-
-    /**
      * 自定义语法转换，在 `emit` 之前执行
      *
      * ```typescript
@@ -116,6 +117,8 @@ export interface Ts2phpOptions {
      */
     customTransformers?: ts.TransformerFactory<ts.SourceFile | ts.Bundle>[]
 }
+
+export interface Ts2phpOptions extends Ts2phpCompileOptions, Ts2phpConstructOptions {}
 
 export interface PHPClass {}
 
@@ -134,4 +137,12 @@ export function compile(filePath: string, options?: Ts2phpOptions): {
 
     /** 错误信息数组 */
     errors: ErrorInfo[]
+};
+
+export class Ts2Php {
+    constructor(options?: Ts2phpConstructOptions)
+    compile(filePath: string, options?: Ts2phpCompileOptions): {
+        phpCode: string;
+        errors: ErrorInfo[];
+    };
 }


### PR DESCRIPTION
允许单个 Project 实例，在我的项目里性能有 2 倍提升。

```
npm run build-e2e  43.92s user 1.68s system 162% cpu 27.983 total
npm run build-e2e  19.99s user 0.72s system 157% cpu 13.183 total
```

两个遗留 todo：

1. 先暴力地把所有 options 都灌进去 compile 方法，constructor 只接受 compilerOptions。后续可以把更多静态的参数挪到 constructor 里面。
2. features 下的 .ts 都没有 export 因此 TypeScript 认为它们都是 global 模块，放在同一个 project 里会冲突。后续做成 module 后再优化其性能。