### PR TITLE
feat: support not emitting `use`

### DIFF
--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -2187,6 +2187,9 @@ export function emitFile(
             const moduleName = getImportModuleName(importNode);
             node.forEachChild((element: ts.ImportSpecifier) => {
                 if (isClassLike(element.name, typeChecker)) {
+                    if (state.modules[moduleName] && state.modules[moduleName].used) {
+                        return;
+                    }
                     writePunctuation("use");
                     writeSpace();
                     const namespace = state.modules[moduleName] && state.modules[moduleName].namespace;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -23,6 +23,11 @@ export interface ModuleInfo {
     namespace?: string | false;
 
     /**
+     * 是否已经 use 过
+     */
+    used?: boolean;
+
+    /**
      * 是否已经被引入，如果是 true，不会输出 require_once
      *
      * @default false


### PR DESCRIPTION
因为 PHP 不允许多次 `use` 同一个 name。如果文件中已经有一个 `use`，第二个就会 Fatal。

```
Fatal error: Cannot use xxx as xxx because the name is already in use in xxx.php on line xx
```

场景是一个文件中，部分代码由 ts2php 生成，部分代码由 san-ssr 生成，有些已经 use 过的希望能通过配置不再输出 `use`。