### PR TITLE
fix: keep extension name in import specifier

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,8 +42,7 @@ const defaultOptions = {
             return JSON.stringify(moduleIt.path);
         }
         const isRelative = /^\./.test(name);
-        const ext = path.extname(name);
-        const outPath = ext ? (name.replace(new RegExp(ext + '$'), '') + '.php') : (isRelative ? (name + '.php') : name);
+        const outPath = isRelative ? (name + '.php') : name;
         const pathCode = JSON.stringify(outPath);
         return isRelative ? `dirname(__FILE__) . '/' . ${pathCode}` : pathCode;
     },

--- a/test/features/helper/foo.bar.ts
+++ b/test/features/helper/foo.bar.ts
@@ -1,0 +1,3 @@
+export function foo () {
+
+}

--- a/test/features/import.md
+++ b/test/features/import.md
@@ -6,8 +6,11 @@ import
 ```ts
 import {Other_Utils as Util} from './helper/some-utils';
 import {Some_Utils, func as func1} from './helper/some-utils';
+import {foo} from './helper/foo.bar'
 
 import {SomeType, SomeAlias} from './helper/some-types';
+
+foo();
 
 type TplData = {
     src?: string,
@@ -40,6 +43,8 @@ import('./Class').then(function () {
 require_once(dirname(__FILE__) . '/' . "./helper/some-utils.php");
 use \someModule\Other_Utils as Util;
 use \someModule\Some_Utils;
+require_once(dirname(__FILE__) . '/' . "./helper/foo.bar.php");
+\someModule\foo();
 $tplData = array();
 $tplData["src"] = Some_Utils::makeTcLink("url");
 $tplData["title"] = Some_Utils::highlight("title");


### PR DESCRIPTION
对于 `import "./foo.bar"` 来讲，extname 是 `.bar` 会被移除，因此会被编译成 `require_once(dirname(__FILE__) . '/' . "./foo");` 是不正确的。

考虑到除了 json 等需要特殊判断的情况，正常情况下 specifier 都是不带 extname 的，因此默认应保持 extname。