### PR TITLE
fix: emit require_once when target not typed

### DIFF
--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -2061,7 +2061,11 @@ export function emitFile(
 
         const isType = node => {
             const typeNode = node.symbol ? typeChecker.getDeclaredTypeOfSymbol(node.symbol) : null;
-            if (!typeNode || typeNode.aliasSymbol) {
+            if (!typeNode) {
+                validImportMember = true;
+                return
+            }
+            if (typeNode.aliasSymbol) {
                 return;
             }
             const symbolFlags = typeNode.symbol ? typeNode.symbol.getFlags() : true;

--- a/test/features/helper/bar.ts
+++ b/test/features/helper/bar.ts
@@ -1,0 +1,3 @@
+export default class Bar {
+
+}

--- a/test/features/import.md
+++ b/test/features/import.md
@@ -7,6 +7,7 @@ import
 import {Other_Utils as Util} from './helper/some-utils';
 import {Some_Utils, func as func1} from './helper/some-utils';
 import {foo} from './helper/foo.bar'
+import Bar from './helper/bar'
 
 import {SomeType, SomeAlias} from './helper/some-types';
 
@@ -44,6 +45,7 @@ require_once(dirname(__FILE__) . '/' . "./helper/some-utils.php");
 use \someModule\Other_Utils as Util;
 use \someModule\Some_Utils;
 require_once(dirname(__FILE__) . '/' . "./helper/foo.bar.php");
+require_once(dirname(__FILE__) . '/' . "./helper/bar.php");
 \someModule\foo();
 $tplData = array();
 $tplData["src"] = Some_Utils::makeTcLink("url");

--- a/test/features/inheritedVariables.md
+++ b/test/features/inheritedVariables.md
@@ -82,6 +82,7 @@ function noError() {
 ```php
 require_once(dirname(__FILE__) . '/' . "./helper/Class.php");
 use \someModule\Article as Art;
+require_once(dirname(__FILE__) . '/' . "./helper/export.php");
 $a = array(
     "b" => "123456"
 );


### PR DESCRIPTION
当目标文件中的类型没法推测到的时候，也 require_once 对方文件。即只有明确知道被引用的是 interface 时才不去 require_once。具体有两种场景中之前都不会生成 require_once，patch 之后会生成：

1. 被引用的 Symbol 未定义，比如 `import {foo} from './foo'` 但 `./foo.ts` 中没有定义 `foo`
2. 引用默认导出，比如 `import foo from './foo'` 无论 `./foo.tx` 是否包含 `foo` 的定义。

### TODO

最新的 TypeScript 提出了 `import type` 语法，后续我们可以只在 `import type` 时不生成 `require_once`。