### PR TITLE
feat: support import module/path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import {setState} from './state';
 import buildInPlugins from './features/index';
 import {transform} from './transformer';
 import {Ts2phpOptions, Ts2phpConstructOptions, Ts2phpCompileOptions, ModuleInfo} from '../types/index';
+import { isRelativePath } from './utilities/index';
 
 const defaultOptions = {
     showDiagnostics: true,
@@ -41,7 +42,7 @@ const defaultOptions = {
         if (moduleIt && moduleIt.path) {
             return JSON.stringify(moduleIt.path);
         }
-        const isRelative = /^\./.test(name);
+        const isRelative = isRelativePath(name);
         const outPath = isRelative ? (name + '.php') : name;
         const pathCode = JSON.stringify(outPath);
         return isRelative ? `dirname(__FILE__) . '/' . ${pathCode}` : pathCode;

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,0 +1,3 @@
+export function isRelativePath(path: string) {
+    return /^\./.test(path);
+}

--- a/test/features/import.md
+++ b/test/features/import.md
@@ -10,6 +10,9 @@ import {foo} from './helper/foo.bar'
 import Bar from './helper/bar'
 
 import {SomeType, SomeAlias} from './helper/some-types';
+import camelcase from 'camelcase/index';
+
+camelcase('aaa-bbb-ccc');
 
 foo();
 
@@ -46,6 +49,8 @@ use \someModule\Other_Utils as Util;
 use \someModule\Some_Utils;
 require_once(dirname(__FILE__) . '/' . "./helper/foo.bar.php");
 require_once(dirname(__FILE__) . '/' . "./helper/bar.php");
+require_once(bbb-camelcase/index);
+camelcase("aaa-bbb-ccc");
 \someModule\foo();
 $tplData = array();
 $tplData["src"] = Some_Utils::makeTcLink("url");

--- a/test/index.ts
+++ b/test/index.ts
@@ -46,6 +46,9 @@ function processTestGroup(group: Group) {
                     modules: {
                         'vue': {
                             required: true
+                        },
+                        'camelcase': {
+                            path: 'bbb-camelcase'
                         }
                     },
                     getModuleNamespace(name) {


### PR DESCRIPTION
When setting `modules` option in compiler:

```
ts2php.compile(path, {
    modules: {
        'camelcase': {
            path: 'bbb-camelcase'
        }
    }
});
```

this can be compile properly:

```
import camelcase from 'camelcase';
```

but this can't:

```
import camelcase from 'camelcase/index';
```
------

We should spilt the module specifier into two parts, `module name` and `module pathname` (but leave relative path unchanged).

Only use `module name` to match the `modules` option