### PR TITLE
fix: import from dir

### DIFF
--- a/test/features/helper/foo/index.ts
+++ b/test/features/helper/foo/index.ts
@@ -1,0 +1,1 @@
+export default function foo () {};

--- a/test/features/import.md
+++ b/test/features/import.md
@@ -97,3 +97,15 @@ require_once("abcdef/multi-files/square.php");
 require_once("aaa/bbb.php");
 require_once("aaa/bbb/ccc.php");
 ```
+
+## import path is a directory
+
+```ts
+import foo from './helper/foo';
+foo();
+```
+
+```php
+require_once(dirname(__FILE__) . '/' . "./helper/foo/index.php");
+foo();
+```

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -92,9 +92,10 @@ export interface Ts2phpCompileOptions {
      *
      * @params importPath 模块引入路径
      * @params module 模块相关信息
+     * @params dirname 当前文件所在目录
      * @returns 路径代码
      */
-    getModulePathCode?: (importPath: string, module?: ts.ResolvedModuleFull, moduleIt?: ModuleInfo) => string;
+    getModulePathCode?: (importPath: string, module?: ts.ResolvedModuleFull, moduleIt?: ModuleInfo, dirname?: string) => string;
 
     /**
      * 获取外部模块的命名空间


### PR DESCRIPTION
当引用路径为相对路径（可能是文件，也可能是目录）时，通过对比当前文件的 `dirname` 和引用文件的 `resolvedFileName`  获得真实路径